### PR TITLE
fixes regex delimiter escaping

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -454,7 +454,7 @@ class MockCollection extends Collection
 
         if ($constraint instanceof Regex) {
             return function ($val) use ($constraint): bool {
-                $pattern = preg_quote($constraint->getPattern(), '#');
+                $pattern = str_replace('#', '\\#', $constraint->getPattern());
                 return preg_match('#' . $pattern . '#' . $constraint->getFlags(), $val);
             };
         }

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -503,7 +503,7 @@ class MockCollectionTest extends \PHPUnit_Framework_TestCase
             ['foo' => 'baz', 'bar' => 2],
         ]);
 
-        $regex = new Regex('Foo', 'i');
+        $regex = new Regex('^Foo', 'i');
         $result = $this->col->findOne(['foo' => $regex]);
 
         assertThat($result['foo'], equalTo('foo'));


### PR DESCRIPTION
@martin-helmich you can not use preg_quote here otherwise you will break the regex.
Thanks for the merge!