### PR TITLE
integrated type mapping

### DIFF
--- a/src/MockDatabase.php
+++ b/src/MockDatabase.php
@@ -24,13 +24,27 @@ class MockDatabase extends Database
 
     /** @var Collection **/
     private $collections = [];
+    
+    /** @var array **/
+    private $options = [];
 
     /**
      * @param string $name
      */
-    public function __construct(string $name = 'database')
+    public function __construct(string $name = 'database', array $options = [])
     {
         $this->name = $name;
+        $this->options = $options;
+    }
+
+    /**
+     * Get options
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 
     /**


### PR DESCRIPTION
Features:

MongoDB mock can now handle a typeMap given on any level (database, collection and operation level):

* MockDatabase now accepts $options
* MockCollection now accepts $options
* MockCollection $options can be used to set a typeMap
* MockCollection find() and findOne() accept typeMap as an option parameter
* find() now converts BSONDocument/arrays into typeMap given


@martin-helmich thanks for merging