### PR TITLE
Throwing RuntimeException upon inserting document with and existing _id in the collection

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -13,6 +13,7 @@ use MongoDB\Collection;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Model\IndexInfoIteratorIterator;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 
 /**
  * A mocked MongoDB collection
@@ -98,6 +99,14 @@ class MockCollection extends Collection
     {
         if (!isset($document['_id'])) {
             $document['_id'] = new ObjectID();
+        } else {
+            // make sure document with the same id does not exist
+            foreach ($this->documents as $doc) {
+                // if document with the same id already exists
+                if ($doc['_id'] == $document['_id']) {
+                    throw new DriverRuntimeException();
+                }
+            }
         }
 
         if (!$document instanceof BSONDocument) {

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -12,6 +12,7 @@ use MongoDB\InsertOneResult;
 use MongoDB\UpdateResult;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 
 class MockCollectionTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,6 +37,22 @@ class MockCollectionTest extends \PHPUnit_Framework_TestCase
 
         assertThat($find, logicalNot(isNull()));
         assertThat($find['foo'], equalTo('bar'));
+    }
+
+    public function testInsertOneDocumentWithExistingId()
+    {
+        $result = $this->col->insertOne([
+            '_id' => 'baz',
+            'foo' => 'bar'
+        ]);
+
+        $this->expectException(DriverRuntimeException::class);
+        
+        // inserting a document with the same _id (baz)
+        $result = $this->col->insertOne([
+            '_id' => 'baz',
+            'bat' => 'dog'
+        ]);        
     }
 
     /**


### PR DESCRIPTION
This is a simple tweak to handle inserting documents with the same `_id`. I have some ideas to implement unique indices. The latter case is not addressed in this PR.