### PR TITLE
PHPUnit 7 compatibility (with PHP 7.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 sudo: false
 php:
-  - 7.0
+  - 7.1
 install:
   - pecl install mongodb
   - composer install --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
     }
   ],
   "require": {
-    "php": ">=7.0.0",
+    "php": ">=7.1.0",
     "ext-mongodb": "*",
     "mongodb/mongodb": "^1.0",
-    "phpunit/phpunit": "^5.2"
+    "phpunit/phpunit": "^7.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
         bootstrap="vendor/autoload.php"
         colors="true">
     <testsuites>

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -5,7 +5,7 @@ namespace Helmich\MongoMock;
 use Helmich\MongoMock\Assert\HasDocumentConstraint;
 use Helmich\MongoMock\Assert\IndexWasCreatedConstraint;
 use Helmich\MongoMock\Assert\QueryWasExecutedConstraint;
-use PHPUnit_Framework_Constraint as Constraint;
+use PHPUnit\Framework\Constraint as Constraint;
 
 /**
  * Helper class containing static factory methods

--- a/src/Assert/HasDocumentConstraint.php
+++ b/src/Assert/HasDocumentConstraint.php
@@ -3,6 +3,7 @@
 namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\MockCollection;
+use PHPUnit\Framework\Constraint\Constraint;
 
 class HasDocumentConstraint extends Constraint
 {

--- a/src/Assert/HasDocumentConstraint.php
+++ b/src/Assert/HasDocumentConstraint.php
@@ -3,6 +3,7 @@
 namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\MockCollection;
+use PHPUnit\Framework\Constraint;
 
 class HasDocumentConstraint extends Constraint
 {

--- a/src/Assert/HasDocumentConstraint.php
+++ b/src/Assert/HasDocumentConstraint.php
@@ -4,7 +4,7 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\MockCollection;
 
-class HasDocumentConstraint extends \PHPUnit_Framework_Constraint
+class HasDocumentConstraint extends Constraint
 {
 
     /**
@@ -18,7 +18,7 @@ class HasDocumentConstraint extends \PHPUnit_Framework_Constraint
         $this->filter = $filter;
     }
 
-    protected function matches($other)
+    protected function matches($other): bool
     {
         if (!$other instanceof MockCollection) {
             return false;
@@ -32,7 +32,7 @@ class HasDocumentConstraint extends \PHPUnit_Framework_Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'has document that matches ' . json_encode($this->filter);
     }

--- a/src/Assert/HasDocumentConstraint.php
+++ b/src/Assert/HasDocumentConstraint.php
@@ -3,7 +3,6 @@
 namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\MockCollection;
-use PHPUnit\Framework\Constraint;
 
 class HasDocumentConstraint extends Constraint
 {

--- a/src/Assert/IndexWasCreatedConstraint.php
+++ b/src/Assert/IndexWasCreatedConstraint.php
@@ -4,6 +4,7 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\Log\Index;
 use Helmich\MongoMock\MockCollection;
+use PHPUnit\Framework\Constraint;
 
 class IndexWasCreatedConstraint extends Constraint
 {

--- a/src/Assert/IndexWasCreatedConstraint.php
+++ b/src/Assert/IndexWasCreatedConstraint.php
@@ -4,6 +4,7 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\Log\Index;
 use Helmich\MongoMock\MockCollection;
+use PHPUnit\Framework\Constraint\Constraint;
 
 class IndexWasCreatedConstraint extends Constraint
 {

--- a/src/Assert/IndexWasCreatedConstraint.php
+++ b/src/Assert/IndexWasCreatedConstraint.php
@@ -4,7 +4,6 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\Log\Index;
 use Helmich\MongoMock\MockCollection;
-use PHPUnit\Framework\Constraint;
 
 class IndexWasCreatedConstraint extends Constraint
 {

--- a/src/Assert/IndexWasCreatedConstraint.php
+++ b/src/Assert/IndexWasCreatedConstraint.php
@@ -5,7 +5,7 @@ namespace Helmich\MongoMock\Assert;
 use Helmich\MongoMock\Log\Index;
 use Helmich\MongoMock\MockCollection;
 
-class IndexWasCreatedConstraint extends \PHPUnit_Framework_Constraint
+class IndexWasCreatedConstraint extends Constraint
 {
 
     /**
@@ -24,7 +24,7 @@ class IndexWasCreatedConstraint extends \PHPUnit_Framework_Constraint
         $this->options = $options;
     }
 
-    protected function matches($other)
+    protected function matches($other): bool
     {
         if (!$other instanceof MockCollection) {
             return false;
@@ -46,7 +46,7 @@ class IndexWasCreatedConstraint extends \PHPUnit_Framework_Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return 'has index of ' . json_encode($this->key);
     }

--- a/src/Assert/QueryWasExecutedConstraint.php
+++ b/src/Assert/QueryWasExecutedConstraint.php
@@ -4,7 +4,6 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\Log\Query;
 use Helmich\MongoMock\MockCollection;
-use PHPUnit\Framework\Constraint;
 
 class QueryWasExecutedConstraint extends Constraint
 {

--- a/src/Assert/QueryWasExecutedConstraint.php
+++ b/src/Assert/QueryWasExecutedConstraint.php
@@ -5,7 +5,7 @@ namespace Helmich\MongoMock\Assert;
 use Helmich\MongoMock\Log\Query;
 use Helmich\MongoMock\MockCollection;
 
-class QueryWasExecutedConstraint extends \PHPUnit_Framework_Constraint
+class QueryWasExecutedConstraint extends Constraint
 {
 
     /** @var array */
@@ -21,7 +21,7 @@ class QueryWasExecutedConstraint extends \PHPUnit_Framework_Constraint
         $this->options = $options;
     }
 
-    protected function matches($other)
+    protected function matches($other): bool
     {
         if (!$other instanceof MockCollection) {
             return false;
@@ -43,7 +43,7 @@ class QueryWasExecutedConstraint extends \PHPUnit_Framework_Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string 
     {
         return 'executed query by ' . json_encode($this->filter);
     }

--- a/src/Assert/QueryWasExecutedConstraint.php
+++ b/src/Assert/QueryWasExecutedConstraint.php
@@ -4,6 +4,7 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\Log\Query;
 use Helmich\MongoMock\MockCollection;
+use PHPUnit\Framework\Constraint;
 
 class QueryWasExecutedConstraint extends Constraint
 {

--- a/src/Assert/QueryWasExecutedConstraint.php
+++ b/src/Assert/QueryWasExecutedConstraint.php
@@ -4,6 +4,7 @@ namespace Helmich\MongoMock\Assert;
 
 use Helmich\MongoMock\Log\Query;
 use Helmich\MongoMock\MockCollection;
+use PHPUnit\Framework\Constraint\Constraint;
 
 class QueryWasExecutedConstraint extends Constraint
 {

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -13,6 +13,7 @@ use MongoDB\UpdateResult;
 use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
+use PHPUnit\Framework\TestCase;
 
 class MockCollectionTest extends TestCase
 {
@@ -549,7 +550,7 @@ class MockCollectionTest extends TestCase
             }
         ]);
         $result = iterator_to_array($result);
-
+        
         assertThat(count($result), equalTo(1));
         assertThat($result[0]['foo'], equalTo('bar'));
     }
@@ -568,7 +569,7 @@ class MockCollectionTest extends TestCase
             'foo' => equalTo('bar')
         ]);
         $result = iterator_to_array($result);
-
+        
         assertThat(count($result), equalTo(1));
         assertThat($result[0]['foo'], equalTo('bar'));
     }

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -14,7 +14,7 @@ use MongoDB\Model\BSONArray;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 
-class MockCollectionTest extends \PHPUnit_Framework_TestCase
+class MockCollectionTest extends TestCase
 {
     /** @var Collection */
     private $col;


### PR DESCRIPTION
This is a little correction on @jbuchmillerRio pull request: using PHPUnit 7 requires PHP 7.1