### PR TITLE
Make `find()` return clones instead of references

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -284,7 +284,7 @@ class MockCollection extends Collection
                     $limit--;
                 }
 
-                $cursor[] = $this->typeMap($doc, $typeMap);
+                $cursor[] = $this->typeMap(clone $doc, $typeMap);
             }
         }
 

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -1058,15 +1058,23 @@ class MockCollectionTest extends TestCase
     public function testFindReturnsClonesNotReferences ()
     {
         $collection = new MockCollection('anyCollection');
-        $documentId = $collection->insertOne(['foo' => 'bar'])->getInsertedId();
+        $documentId = $collection->insertOne(['foo' => 'bar', 'bax' => ['hello' => 'world']])->getInsertedId();
 
         $documentBeforeUpdate = $collection->findOne(['_id' => $documentId]);
-        $collection->updateOne(['_id' => $documentId], ['$set' => ['foo' => 'baz']]);
+        $collection->updateOne(['_id' => $documentId], ['$set' => ['foo' => 'baz', 'bax' => ['hello' => 'planet']]]);
         $documentAfterUpdate = $collection->findOne(['_id' => $documentId]);
 
+        // Test shallow object
         assertNotSame($documentBeforeUpdate, $documentAfterUpdate);
         assertThat($documentBeforeUpdate['foo'], equalTo('bar'));
         assertThat($documentAfterUpdate['foo'], equalTo('baz'));
+
+        // Test sub-documents
+        $subDocumentBeforeUpdate = $documentBeforeUpdate['bax'];
+        $subDocumentAfterUpdate = $documentAfterUpdate['bax'];
+        assertNotSame($subDocumentBeforeUpdate, $subDocumentAfterUpdate);
+        assertThat($subDocumentBeforeUpdate['hello'], equalTo('world'));
+        assertThat($subDocumentAfterUpdate['hello'], equalTo('planet'));
     }
 
 }

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -1055,4 +1055,18 @@ class MockCollectionTest extends TestCase
         assertThat($first['name'], equalTo('foo_1_bar_1'));
     }
 
+    public function testFindReturnsClonesNotReferences ()
+    {
+        $collection = new MockCollection('anyCollection');
+        $documentId = $collection->insertOne(['foo' => 'bar'])->getInsertedId();
+
+        $documentBeforeUpdate = $collection->findOne(['_id' => $documentId]);
+        $collection->updateOne(['_id' => $documentId], ['$set' => ['foo' => 'baz']]);
+        $documentAfterUpdate = $collection->findOne(['_id' => $documentId]);
+
+        assertNotSame($documentBeforeUpdate, $documentAfterUpdate);
+        assertThat($documentBeforeUpdate['foo'], equalTo('bar'));
+        assertThat($documentAfterUpdate['foo'], equalTo('baz'));
+    }
+
 }


### PR DESCRIPTION
This PR fixes #26 and adds a test to ensure `find()` returns referenes only.