### PR TITLE
Typemapping fix

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -69,12 +69,8 @@ class MockCollection extends Collection
     /** @var array */
     private $options = [];
 
-    /** @var array */
-    private $typeMap = [
-        'array' => BSONArray::class,
-        'document' => BSONDocument::class,
-        'root' => BSONDocument::class
-    ];
+    /** @var TypeMapper */
+    private $typeMapper;
 
     /**
      * @param string $name
@@ -92,9 +88,7 @@ class MockCollection extends Collection
             $this->options = $options;
         }
 
-        if (isset($this->options['typeMap'])) {
-            $this->typeMap = $this->options['typeMap'];
-        }
+        $this->typeMapper = TypeMapper::createWithDefault($this->options['typeMap'] ?? []);
     }
 
     public function insertOne($document, array $options = [])
@@ -243,10 +237,9 @@ class MockCollection extends Collection
 
     public function find($filter = [], array $options = []): MockCursor
     {
+        $typeMapper = $this->typeMapper;
         if (isset($options['typeMap'])) {
-            $typeMap = array_merge($this->typeMap, $options['typeMap']);
-        } else {
-            $typeMap = $this->typeMap;
+            $typeMapper = $typeMapper->mergeWith(new TypeMapper($options['typeMap']));
         }
 
         // record query for future assertions
@@ -299,7 +292,7 @@ class MockCollection extends Collection
                     $limit--;
                 }
 
-                $cursor[] = $this->typeMap(clone $doc, $typeMap);
+                $cursor[] = $typeMapper->map(clone $doc);
             }
         }
 
@@ -313,31 +306,6 @@ class MockCollection extends Collection
             return $result;
         }
         return null;
-    }
-
-    private function typeMap(BSONDocument $doc, array $typeMap)
-    {
-        $doc = $this->typeMapArray($doc, $typeMap);
-
-        if ($typeMap['document'] === 'array') {
-            $doc = $doc->getArrayCopy();
-        } elseif ($typeMap['document'] !== BSONDocument::class) {
-            $doc = new $typeMap['document']($doc->getArrayCopy());
-        }
-
-        return $doc;
-    }
-
-    private function typeMapArray($doc, array $typeMap)
-    {
-        foreach ($doc as $key => &$value) {
-            if (is_array($value) && $typeMap['array'] !== 'array') {
-                $value = $this->typeMapArray($value, $typeMap);
-                $value = new $typeMap['array']($value);
-            }
-        }
-
-        return $doc;
     }
 
     public function count($filter = [], array $options = [])

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -292,7 +292,7 @@ class MockCollection extends Collection
                     $limit--;
                 }
 
-                $cursor[] = $typeMapper->map(clone $doc);
+                $cursor[] = $typeMapper->map($doc);
             }
         }
 

--- a/src/TypeMapper.php
+++ b/src/TypeMapper.php
@@ -35,6 +35,20 @@ class TypeMapper {
     }
 
     /**
+     * Merges a TypeMap with another TypeMap and returns a new mapper instance
+     *
+     * @param TypeMapper $typeMapper
+     * @return TypeMapper
+     */
+    function mergeWith(TypeMapper $typeMapper) : TypeMapper
+    {
+        $instance = clone $this;
+        $instance->typeMap = array_merge($instance->typeMap, $typeMapper->typeMap);
+
+        return $instance;
+    }
+
+    /**
      * @param BSONDocument $document
      * @return BSONDocument|array
      */
@@ -62,20 +76,6 @@ class TypeMapper {
         }
 
         return $document;
-    }
-
-    /**
-     * Merges a TypeMap with another TypeMap and returns a new mapper instance
-     *
-     * @param TypeMapper $typeMapper
-     * @return TypeMapper
-     */
-    function mergeWith(TypeMapper $typeMapper) : TypeMapper
-    {
-        $instance = clone $this;
-        $instance->typeMap = array_merge($instance->typeMap, $typeMapper->typeMap);
-
-        return $instance;
     }
 
 }

--- a/src/TypeMapper.php
+++ b/src/TypeMapper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Helmich\MongoMock;
+
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
+
+class TypeMapper {
+
+    /** @const array */
+    const DEFAULT_TYPE_MAP = [
+        'array' => BSONArray::class,
+        'document' => BSONDocument::class,
+        'root' => BSONDocument::class
+    ];
+
+    /** @var array */
+    private $typeMap;
+
+    /**
+     * @param array $typeMapDefaultOverwrite
+     * @return TypeMapper
+     */
+    static function createWithDefault (array $typeMapDefaultOverwrite = []) : TypeMapper
+    {
+        return new static(array_merge(static::DEFAULT_TYPE_MAP, $typeMapDefaultOverwrite));
+    }
+
+    /**
+     * @param array $typeMap
+     */
+    function __construct (array $typeMap)
+    {
+        $this->typeMap = $typeMap;
+    }
+
+    /**
+     * @param BSONDocument $document
+     * @return BSONDocument|array
+     */
+    function map (BSONDocument $document) : iterable
+    {
+        /** @var BSONDocument $document */
+        $document = $this->typeMapRecursively($document);
+
+        if ($this->typeMap['document'] === 'array') {
+            $document = $document->getArrayCopy();
+        } elseif ($this->typeMap['document'] !== BSONDocument::class) {
+            $document = new $this->typeMap['document']($document->getArrayCopy());
+        }
+
+        return $document;
+    }
+
+    private function typeMapRecursively ($document)
+    {
+        foreach ($document as $key => &$value) {
+            if (is_array($value) && $this->typeMap['array'] !== 'array') {
+                $value = $this->typeMapRecursively($value);
+                $value = new $this->typeMap['array']($value);
+            }
+        }
+
+        return $document;
+    }
+
+    /**
+     * Merges a TypeMap with another TypeMap and returns a new mapper instance
+     *
+     * @param TypeMapper $typeMapper
+     * @return TypeMapper
+     */
+    function mergeWith(TypeMapper $typeMapper) : TypeMapper
+    {
+        $instance = clone $this;
+        $instance->typeMap = array_merge($instance->typeMap, $typeMapper->typeMap);
+
+        return $instance;
+    }
+
+}

--- a/tests/TypeMapperTest.php
+++ b/tests/TypeMapperTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Helmich\MongoMock\Tests;
+
+use Helmich\MongoMock\TypeMapper;
+use MongoDB\BSON\Type;
+use MongoDB\Model\BSONArray;
+use MongoDB\Model\BSONDocument;
+use PHPUnit\Framework\TestCase;
+
+class TypeMapperTest extends TestCase
+{
+    function testMapWithDefaultOptions () {
+        $typeMapper = TypeMapper::createWithDefault();
+        $mapped = $typeMapper->map(new BSONDocument(['foo' => 'bar', 'list' => [1, 2, 3]]));
+
+        $this->assertInstanceOf(BSONDocument::class, $mapped);
+        $this->assertArrayHasKey('foo', $mapped);
+        $this->assertSame('bar', $mapped['foo']);
+        $this->assertInstanceOf(BSONArray::class, $mapped['list']);
+        $this->assertCount(3, $mapped['list']);
+    }
+
+    function testMapWithDocumentAsArrayOption () {
+        $typeMapper = TypeMapper::createWithDefault(['document' => BSONArray::class]);
+        $mapped = $typeMapper->map(new BSONDocument(['foo' => 'bar', 'list' => [1, 2, 3]]));
+
+        $this->assertInstanceOf(BSONArray::class, $mapped);
+        $this->assertArrayHasKey('foo', $mapped);
+        $this->assertSame('bar', $mapped['foo']);
+        $this->assertInstanceOf(BSONArray::class, $mapped['list']);
+        $this->assertCount(3, $mapped['list']);
+    }
+
+    function testMapWithSubObjectAsArray () {
+        $typeMapper = TypeMapper::createWithDefault();
+        $mapped = $typeMapper->map(new BSONDocument(['foo' => ['bar' => 1, 'baz' => 2]]));
+
+        $this->assertInstanceOf(BSONDocument::class, $mapped);
+        $this->assertArrayHasKey('foo', $mapped);
+        $this->assertInstanceOf(BSONDocument::class, $mapped['foo']);
+        $this->assertSame(1, $mapped['foo']['bar']);
+        $this->assertSame(2, $mapped['foo']['baz']);
+    }
+
+}

--- a/tests/TypeMapperTest.php
+++ b/tests/TypeMapperTest.php
@@ -25,10 +25,11 @@ class TypeMapperTest extends TestCase
         $typeMapper = TypeMapper::createWithDefault(['document' => 'array', 'array' => 'array']);
         $mapped = $typeMapper->map(new BSONDocument(['foo' => 'bar', 'list' => [1, 2, 3]]));
 
-        $this->assertIsArray($mapped);
         $this->assertArrayHasKey('foo', $mapped);
         $this->assertSame('bar', $mapped['foo']);
-        $this->assertIsArray($mapped['list']);
+
+        // workaround for missing assertIsArray() in phpunit6 and deprecated assertInternalType in phpunit8
+        $this->assertTrue(is_array($mapped['list']));
         $this->assertCount(3, $mapped['list']);
     }
 

--- a/tests/TypeMapperTest.php
+++ b/tests/TypeMapperTest.php
@@ -21,7 +21,18 @@ class TypeMapperTest extends TestCase
         $this->assertCount(3, $mapped['list']);
     }
 
-    function testMapWithDocumentAsArrayOption () {
+    function testMapWithDocumentAndArraysAsArrayOption () {
+        $typeMapper = TypeMapper::createWithDefault(['document' => 'array', 'array' => 'array']);
+        $mapped = $typeMapper->map(new BSONDocument(['foo' => 'bar', 'list' => [1, 2, 3]]));
+
+        $this->assertIsArray($mapped);
+        $this->assertArrayHasKey('foo', $mapped);
+        $this->assertSame('bar', $mapped['foo']);
+        $this->assertIsArray($mapped['list']);
+        $this->assertCount(3, $mapped['list']);
+    }
+
+    function testMapWithDocumentAsCustomTypeOption () {
         $typeMapper = TypeMapper::createWithDefault(['document' => BSONArray::class]);
         $mapped = $typeMapper->map(new BSONDocument(['foo' => 'bar', 'list' => [1, 2, 3]]));
 


### PR DESCRIPTION
This PR fixes #32 by correctly treating non-numerically indexed arrays as documents instead of arrays.

I introduced a `TypeMapper` to remove the functionality out of the `MockCollection` class itself. Future type conversions can be made inside this class (e. g. if we have to deal with instances of `stdClass` or similar objects).