### PR TITLE
Add support for selecting element inside array

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -721,6 +721,10 @@ class MockCollection extends Collection
                 return $val->getData() == $constraint;
             }
 
+            if (is_array($val) && is_scalar($constraint)) {
+                return in_array($constraint, $val, true);
+            }
+
             return $val == $constraint;
         };
     }

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -1151,4 +1151,15 @@ class MockCollectionTest extends TestCase
         $documentAfterUpdate = $col->findOne(['_id' => $insertOneResult->getInsertedId()]);
         assertThat($documentAfterUpdate['foo']['foo']['bar'], equalTo("azerty"), $documentAfterUpdate['foo']['foo']['bar']);
     }
+
+    public function testFindScalarValueInArray()
+    {
+        $col = new MockCollection('foo');
+        $col->insertOne(['foo' => ['bar', 'baz']]);
+
+        $document = $col->findOne(['foo' => 'bar']);
+
+        assertInstanceOf(BSONDocument::class, $document);
+        assertArrayHasKey('foo', $document);
+    }
 }


### PR DESCRIPTION
As of the [MongoDB doc](https://docs.mongodb.com/manual/tutorial/query-arrays/#query-an-array-for-an-element), the following query:
```php
$collection->find(['foo' => 'bar']);
```
should match for a document like
```json
{
    "foo": ["bar", "baz"]
}
```
However, mongomock currently doesn't do it. This PR adds support for `in_array` matching if
- the given value is an array
- the given constraint is a scalar value

It also adds a test to confirm the behaviour.
