### PR TITLE
Update deleteMany() return value to extend DeleteResult.php

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -134,12 +134,15 @@ class MockCollection extends Collection
     public function deleteMany($filter, array $options = [])
     {
         $matcher = $this->matcherFromQuery($filter);
+        $count = 0;
         foreach ($this->documents as $i => $doc) {
             if ($matcher($doc)) {
                 unset($this->documents[$i]);
+                $count++;
             }
         }
         $this->documents = array_values($this->documents);
+        return new MockDeleteResult($count, $count);
     }
 
     public function updateOne($filter, $update, array $options = [])

--- a/src/MockDeleteResult.php
+++ b/src/MockDeleteResult.php
@@ -1,24 +1,24 @@
 <?php
 namespace Helmich\MongoMock;
 
-use MongoDB\UpdateResult;
+use MongoDB\DeleteResult;
 
-class MockUpdateResult extends UpdateResult
+class MockDeleteResult extends DeleteResult
 {
     private $matched;
     private $modified;
-    private $upsertedIds;
+    private $deletedIds;
 
     /**
      * @param int $matched
      * @param int $modified
-     * @param array $upsertedIds
+     * @param array $deletedIds
      */
-    public function __construct($matched=0, $modified=0, array $upsertedIds=[])
+    public function __construct($matched=0, $modified=0, array $deletedIds=[])
     {
         $this->matched = $matched;
         $this->modified = $modified;
-        $this->upsertedIds = $upsertedIds;
+        $this->deletedIds = $deletedIds;
     }
 
     public function getMatchedCount()
@@ -31,19 +31,18 @@ class MockUpdateResult extends UpdateResult
         return $this->modified;
     }
 
-    public function getUpsertedCount()
+    public function getDeletedCount()
     {
-        return count($this->upsertedIds);
+        return count($this->deletedIds);
     }
 
-    public function getUpsertedId()
+    public function getDeletedIds()
     {
-        return $this->upsertedIds;
+        return $this->deletedIds;
     }
 
     public function isAcknowledged()
     {
         return true;
     }
-
 }


### PR DESCRIPTION
`deleteMany()` doesn't return the correct object at the moment, leaving the functions that call it to throw an error like this:

```
Error : Call to a member function isAcknowledged() on null
```
