### PR TITLE
Fixed composer version 1.10 to run tests

### DIFF
--- a/phpunit.DOCKERFILE
+++ b/phpunit.DOCKERFILE
@@ -2,8 +2,4 @@ FROM php:7.2
 
 RUN pecl install --force mongodb
 RUN echo "extension=mongodb.so" > /usr/local/etc/php/conf.d/mongodb.ini
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-    php -r "if (hash_file('sha384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
-    php composer-setup.php && \
-    php -r "unlink('composer-setup.php');" && \
-    mv composer.phar /usr/bin/composer
+COPY --from=composer:1.10 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
### Problem
Downloading [getcomposer.org/installer](https://getcomposer.org/installer) and check file by `hash_file` is not work when composer version is changes

### Solution
Lock composer version in dockerfile