### PR TITLE
Implement regex operator

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -673,6 +673,20 @@ class MockCollection extends Collection
                                 $result = !$operand;
                             }
                             break;
+                        case '$regex':{
+                            if($operand instanceof \MongoDB\BSON\Regex){
+                                $regex = "/". $operand->getPattern() . "/". $operand->getFlags();
+                                $result = preg_match($regex,$val) === 1;
+                            }else if(is_string($operand)){
+                                if(@preg_match($operand, '') === false){
+                                    throw new Exception("Invalid constraint for operator '" . $type . "'");
+                                }
+                                $result = preg_match($operand,$val) === 1;
+                            }else{
+                                throw new Exception("Invalid constraint for operator '" . $type . "'");
+                            }
+                            break;
+                        }
                         // Custom operators
                         case '$instanceOf':
                             $result = is_a($val, $operand);


### PR DESCRIPTION
Add the ability to use the $regex operator.
The regular expressions can be passed as their **string** representation or through an instance of **\MongoDB\BSON\Regex**.

`$col->count(['foo' => ['$regex' => "/bar/i"]]);`

Same as

`$col->count(['foo' => ['$regex' => new \MongoDB\BSON\Regex("bar","i")]]);`