### PR TITLE
deleteOne must return a DeleteResult

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -374,13 +374,18 @@ class MockCollection extends Collection
     public function deleteOne($filter, array $options = [])
     {
         $matcher = $this->matcherFromQuery($filter);
+        $count = 0;
+        $deletedIds = [];
         foreach ($this->documents as $i => $doc) {
             if ($matcher($doc)) {
+                $deletedIds []= $doc['_id'];
                 unset($this->documents[$i]);
                 $this->documents = array_values($this->documents);
-                return;
+                $count++;
+                break;
             }
         }
+        return new MockDeleteResult($count, $count, $deletedIds);
     }
 
     public function distinct($fieldName, $filter = [], array $options = [])

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -281,10 +281,15 @@ class MockCollectionTest extends TestCase
             ['foo' => 'bar', 'bar' => 1],
             ['foo' => 'baz', 'bar' => 2],
         ]);
-        $this->col->deleteOne(['bar' => 1]);
+        
+        $deleteResult = $this->col->deleteOne(['bar' => 1]);
 
         self::assertThat($this->col->count(['bar' => 1]), self::equalTo(1));
         self::assertThat($this->col->count(['bar' => 2]), self::equalTo(1));
+
+        self::assertInstanceOf(\Helmich\MongoMock\MockDeleteResult::class, $deleteResult);
+
+        self::assertEquals(1,$deleteResult->getDeletedCount());
     }
 
     /**


### PR DESCRIPTION
The `deleteOne` method must return an instance of  `MongoDB\DeleteResult`.