### PR TITLE
Fix: Array functions fail against BSONArray

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kevinkl3/mongomock",
+  "name": "helmich/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "helmich/mongomock",
+  "name": "kevinkl3/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -613,13 +613,18 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
-                //cast $val to array if its an instance of BSONArray
-                //this will prevent is_array from failing
+                //cast $val to array if it is an instance of BSONArray
+                //this will prevent is_array,array_reduce... from failing
                 if($val instanceof BSONArray){
                     $val = (array)$val;
                 }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
+                    //cast $operand to array if it is an instance of BSONArray
+                    //this will prevent is_array,array_reduce... from failing
+                    if($operand instanceof BSONArray){
+                        $operand = (array)$operand;
+                    }
                     switch ($type) {
                         // Mongo operators (subset)
                         case '$gt':

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -235,7 +235,6 @@ class MockCollection extends Collection
                 $doc[$k][] = $v;
             }
         }
-
     }
 
     public function find($filter = [], array $options = []): MockCursor
@@ -378,7 +377,7 @@ class MockCollection extends Collection
         $deletedIds = [];
         foreach ($this->documents as $i => $doc) {
             if ($matcher($doc)) {
-                $deletedIds [] = $doc['_id'];
+                $deletedIds[] = $doc['_id'];
                 unset($this->documents[$i]);
                 $this->documents = array_values($this->documents);
                 $count++;
@@ -616,14 +615,14 @@ class MockCollection extends Collection
             return $match = function ($val) use (&$constraint, &$match): bool {
                 //cast $val to array if it is an instance of BSONArray
                 //this will prevent is_array,array_reduce... from failing
-                if($val instanceof BSONArray){
+                if ($val instanceof BSONArray) {
                     $val = (array)$val;
                 }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     //cast $operand to array if it is an instance of BSONArray
                     //this will prevent is_array,array_reduce... from failing
-                    if($operand instanceof BSONArray){
+                    if ($operand instanceof BSONArray) {
                         $operand = (array)$operand;
                     }
                     switch ($type) {

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -614,6 +614,11 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
+                //cast $val to array if its an instance of BSONArray
+                //this will prevent is_array from failing
+                if($val instanceof BSONArray){
+                    $val = (array)$val;
+                }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     switch ($type) {

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -12,6 +12,7 @@ use MongoDB\BSON\Regex;
 use MongoDB\Collection;
 use MongoDB\Driver\Exception\RuntimeException as DriverRuntimeException;
 use MongoDB\Model\BSONDocument;
+use MongoDB\Model\BSONArray;
 use MongoDB\Model\IndexInfoIteratorIterator;
 use MongoDB\Operation\FindOneAndUpdate;
 use PHPUnit\Framework\Constraint\Constraint;


### PR DESCRIPTION
When passing instances of BSONArray to built-in functions like `is_array`, `in_array`, `array_map`, `array_reduce` PHP will fails with a warning similar to:

`in_array() expects parameter 2 to be array, object given...`

This is impacting the function `matcherFromConstraint` which won't return the expected results.