### PR TITLE
Fix: Regex within $in operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kevinkl3/mongomock",
+  "name": "helmich/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "helmich/mongomock",
+  "name": "kevinkl3/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -643,11 +643,11 @@ class MockCollection extends Collection
                                         return ($ac || preg_match($regex,$val) === 1);
                                     }else if(is_string($op)){
                                         if(@preg_match($op, '') === false){
-                                            return ($ac || $op === $val);
+                                            return ($ac || $op == $val);
                                         }
                                         return ($ac || preg_match($op,$val) === 1);
                                     }
-                                    return ($ac || $op === $val);
+                                    return ($ac || $op == $val);
                                 },false);
                             };
                             $result = (!is_array($val))

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -614,6 +614,11 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
+                //cast $val to array if its an instance of BSONArray
+                //this will prevent is_array from failing
+                if($val instanceof BSONArray){
+                    $val = (array)$val;
+                }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     switch ($type) {

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -613,11 +613,6 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
-                //cast $val to array if its an instance of BSONArray
-                //this will prevent is_array from failing
-                if($val instanceof BSONArray){
-                    $val = (array)$val;
-                }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     switch ($type) {
@@ -641,12 +636,26 @@ class MockCollection extends Collection
                             $result = ($val != $operand);
                             break;
                         case '$in':
+                            $matchInArray = function($val, $operand){                                    
+                                return array_reduce($operand,function($ac,$op) use($val){
+                                    if($op instanceof \MongoDB\BSON\Regex){
+                                        $regex = "/". $op->getPattern() . "/". $op->getFlags();
+                                        return ($ac || preg_match($regex,$val) === 1);
+                                    }else if(is_string($op)){
+                                        if(@preg_match($op, '') === false){
+                                            return ($ac || $op === $val);
+                                        }
+                                        return ($ac || preg_match($op,$val) === 1);
+                                    }
+                                    return ($ac || $op === $val);
+                                },false);
+                            };
                             $result = (!is_array($val))
-                                ? in_array($val, $operand)
+                                ? $matchInArray($val,$operand)
                                 : array_reduce(
-                                    $operand,
-                                    function ($acc, $op) use ($val) {
-                                        return ($acc || in_array($op, $val));
+                                    $val,
+                                    function ($acc, $fval) use ($operand,$matchInArray) {
+                                        return ($acc || $matchInArray($fval, $operand));
                                     },
                                     false
                                 );

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -234,7 +234,6 @@ class MockCollection extends Collection
                 $doc[$k][] = $v;
             }
         }
-
     }
 
     public function find($filter = [], array $options = []): MockCursor
@@ -377,7 +376,7 @@ class MockCollection extends Collection
         $deletedIds = [];
         foreach ($this->documents as $i => $doc) {
             if ($matcher($doc)) {
-                $deletedIds [] = $doc['_id'];
+                $deletedIds[] = $doc['_id'];
                 unset($this->documents[$i]);
                 $this->documents = array_values($this->documents);
                 $count++;
@@ -636,25 +635,25 @@ class MockCollection extends Collection
                             $result = ($val != $operand);
                             break;
                         case '$in':
-                            $matchInArray = function($val, $operand){                                    
-                                return array_reduce($operand,function($ac,$op) use($val){
-                                    if($op instanceof \MongoDB\BSON\Regex){
-                                        $regex = "/". $op->getPattern() . "/". $op->getFlags();
-                                        return ($ac || preg_match($regex,$val) === 1);
-                                    }else if(is_string($op)){
-                                        if(@preg_match($op, '') === false){
+                            $matchInArray = function ($val, $operand) {
+                                return array_reduce($operand, function ($ac, $op) use ($val) {
+                                    if ($op instanceof \MongoDB\BSON\Regex) {
+                                        $regex = "/" . $op->getPattern() . "/" . $op->getFlags();
+                                        return ($ac || preg_match($regex, $val) === 1);
+                                    } else if (is_string($op)) {
+                                        if (@preg_match($op, '') === false) {
                                             return ($ac || $op == $val);
                                         }
-                                        return ($ac || preg_match($op,$val) === 1);
+                                        return ($ac || preg_match($op, $val) === 1);
                                     }
                                     return ($ac || $op == $val);
-                                },false);
+                                }, false);
                             };
                             $result = (!is_array($val))
-                                ? $matchInArray($val,$operand)
+                                ? $matchInArray($val, $operand)
                                 : array_reduce(
                                     $val,
-                                    function ($acc, $fval) use ($operand,$matchInArray) {
+                                    function ($acc, $fval) use ($operand, $matchInArray) {
                                         return ($acc || $matchInArray($fval, $operand));
                                     },
                                     false

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -232,10 +232,10 @@ class MockCollectionTest extends TestCase
          * you can only use JavaScript regular expression objects (i.e. /pattern/ ).
          * source: https://www.mongodb.com/docs/manual/reference/operator/query/regex/#-in-expressions
          */
-        $result = $this->col->count(['foo' => ['$in' => ["/barBar/","/barBor/"]]]);
+        $result = $this->col->count(['foo' => ['$in' => ["/barBar/", "/barBor/"]]]);
         self::assertThat($result, self::equalTo(0));
 
-        $result = $this->col->count(['foo' => ['$in' => ["/bar$/","/^Bar/i",]]]);
+        $result = $this->col->count(['foo' => ['$in' => ["/bar$/", "/^Bar/i",]]]);
         self::assertThat($result, self::equalTo(2));
 
         $result = $this->col->count(['foo' => ['$in' => ['/^Bar$/i',]]]);
@@ -247,7 +247,7 @@ class MockCollectionTest extends TestCase
         $result = $this->col->count(['foo' => ['$in' => [new \MongoDB\BSON\Regex("FOOBAR|bad", "i")]]]);
         self::assertThat($result, self::equalTo(3));
 
-        $result = $this->col->count(['foo' => ['$in' => [new \MongoDB\BSON\Regex("ob"),new \MongoDB\BSON\Regex("oof")]]]);
+        $result = $this->col->count(['foo' => ['$in' => [new \MongoDB\BSON\Regex("ob"), new \MongoDB\BSON\Regex("oof")]]]);
         self::assertThat($result, self::equalTo(2));
     }
 


### PR DESCRIPTION
Regular expressions are able to be used within `$in` expressions. 

From: https://www.mongodb.com/docs/manual/reference/operator/query/regex/#-in-expressions
To include a regular expression in an $in query expression, you can only use JavaScript regular expression objects.

For example:
`{ name: { $in: [ /^acme/i, /^ack/ ] } }
`