### PR TITLE
Fix: $exists operator can be parameterized

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kevinkl3/mongomock",
+  "name": "helmich/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "helmich/mongomock",
+  "name": "kevinkl3/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -614,6 +614,11 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
+                //cast $val to array if its an instance of BSONArray
+                //this will prevent is_array from failing
+                if($val instanceof BSONArray){
+                    $val = (array)$val;
+                }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     switch ($type) {

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -613,11 +613,6 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
-                //cast $val to array if its an instance of BSONArray
-                //this will prevent is_array from failing
-                if($val instanceof BSONArray){
-                    $val = (array)$val;
-                }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     switch ($type) {
@@ -666,7 +661,8 @@ class MockCollection extends Collection
                             }
                             break;
                         case '$exists':
-                            $result = $val !== null;
+                            // note that for inexistant fields, val is overridden to be null
+                            return $operand ? $val !== null : $val === null;
                             break;
                         case '$size':
                             $result = count($val) === $operand;

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -733,6 +733,37 @@ class MockCollectionTest extends TestCase
     /**
      * @depends testInsertManyInsertsDocuments
      */
+    public function testFindWorksWithExistsParameterized()
+    {
+        $this->col->insertMany([
+            ['foo' => 'foo', 'bar' => 3, 'krypton' => true],
+            ['foo' => 'bar', 'bar' => 1],
+            ['foo' => 'baz', 'bar' => 2],
+        ]);
+        $result = $this->col->find([
+            'foobar' => ['$exists' => false],
+        ]);
+        $result = iterator_to_array($result);
+        self::assertThat(count($result), self::equalTo(3));
+
+        $result = $this->col->find([
+            'krypton' => ['$exists' => true],
+        ]);
+        $result = iterator_to_array($result);
+        self::assertThat(count($result), self::equalTo(1));
+        self::assertThat($result[0]['foo'], self::equalTo('foo'));
+
+        $result = $this->col->find([
+            'inexistant' => ['$exists' => true],
+        ]);
+        $result = iterator_to_array($result);
+        self::assertThat(count($result), self::equalTo(0));
+    }
+
+
+    /**
+     * @depends testInsertManyInsertsDocuments
+     */
     public function testFindOneFindsOne()
     {
         $this->col->insertMany([


### PR DESCRIPTION
Fixes #44 

The `$exists` expression can be parameterized:
https://www.mongodb.com/docs/manual/reference/operator/query/exists/#-exists

Syntax: `{ field: { $exists: <boolean> } }`

NOTE:
Contrary to the mongodb documentation `php-mongomock` treats `null` fields as non-existent whereas `mongodb` treats then as existent.

**Official Mongodb Documentation:**
When < boolean > is true, [$exists](https://www.mongodb.com/docs/manual/reference/operator/query/exists/#mongodb-query-op.-exists) matches the documents that contain the field, **including documents where the field value is null**. If < boolean > is false, the query returns only the documents that do not contain the field. [[1]](https://www.mongodb.com/docs/manual/reference/operator/query/exists/#footnote-type0)
