### PR TITLE
Feature: $all operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kevinkl3/mongomock",
+  "name": "helmich/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "helmich/mongomock",
+  "name": "kevinkl3/mongomock",
   "description": "Library containing highly intelligent MongoDB mocks for unit testing",
   "type": "library",
   "license": "MIT",

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -614,6 +614,11 @@ class MockCollection extends Collection
 
         if (is_array($constraint)) {
             return $match = function ($val) use (&$constraint, &$match): bool {
+                //cast $val to array if its an instance of BSONArray
+                //this will prevent is_array from failing
+                if($val instanceof BSONArray){
+                    $val = (array)$val;
+                }
                 $result = true;
                 foreach ($constraint as $type => $operand) {
                     switch ($type) {

--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -717,19 +717,22 @@ class MockCollection extends Collection
                             break;
                         case '$all':
                             $result = false;
-                            if(is_array($val)){
-                                if(count($operand) == 1 && is_array($operand[0])){
-                                    $result = count($val) == count($operand[0]) && array_reduce($operand[0],
-                                    function($acc,$op) use($val){
-                                        return $acc && in_array($op,$val,true);
-                                    },true);
+                            if (is_array($val)) {
+                                if (count($operand) == 1 && is_array($operand[0])) {
+                                    $result = count($val) == count($operand[0]) && array_reduce(
+                                        $operand[0],
+                                        function ($acc, $op) use ($val) {
+                                            return $acc && in_array($op, $val, true);
+                                        },
+                                        true
+                                    );
                                 }
-                                $result = $result || array_reduce($operand,function($acc,$op) use($val){
-                                    return $acc && in_array($op,$val,true);
-                                },true);
+                                $result = $result || array_reduce($operand, function ($acc, $op) use ($val) {
+                                    return $acc && in_array($op, $val, true);
+                                }, true);
                             }
                             break;
-                        // Custom operators
+                            // Custom operators
                         case '$instanceOf':
                             $result = is_a($val, $operand);
                             break;

--- a/tests/MockCollectionTest.php
+++ b/tests/MockCollectionTest.php
@@ -217,6 +217,80 @@ class MockCollectionTest extends TestCase
     /**
      * @depends testInsertOneInsertsDocument
      */
+    public function testFindWithAllFilter()
+    {
+        $this->col->insertMany([
+            ['foo' => ['bar', 'baz', 'bad']],
+            ['foo' => ['baz', 'bad']],
+            ['foo' => ['foobar', 'baroof']],
+            ['foo' => [1,2,3], 'bar' => [4,5,6]],
+            ['foo' => [99.99,'bar',10], 'bar' => [false,true]],
+        ]);
+
+        $result = $this->col->count(['foo' => ['$all' => ['bar','baz','foobar','zar']]]);
+        self::assertThat($result, self::equalTo(0));
+
+        $result = $this->col->count(['foo' => ['$all' => ['bar','baz','bad']]]);
+        self::assertThat($result, self::equalTo(1));
+
+        $result = $this->col->count(['foo' => ['$all' => ['foobar', 'baroof']]]);
+        self::assertThat($result, self::equalTo(1));
+        //The $all is equivalent to an $and operation of the specified values;
+        $andResult = $this->col->count(['$and' => [['foo'=>'foobar'],['foo' => 'baroof']]]);
+        self::assertThat($andResult, self::equalTo($result));
+
+        $result = $this->col->count(['foo' => ['$all' => ['baz']]]);
+        self::assertThat($result, self::equalTo(2));
+
+        $result = $this->col->count(['foo' => ['$all' => [3,1,2]], 'bar' => ['$all' => [6,4]] ]);
+        self::assertThat($result, self::equalTo(1));
+
+        $result = $this->col->count(['foo' => ['$all' => [10,99.99000]], 'bar' => ['$all' => [true]] ]);
+        self::assertThat($result, self::equalTo(1));
+
+        $result = $this->col->count(['foo' => ['$all' => [99.99000,'baz']], 'bar' => ['$all' => ['']] ]);
+        self::assertThat($result, self::equalTo(0));
+    }
+
+    /**
+     * @depends testInsertOneInsertsDocument
+     */
+    public function testFindWithAllFilterNestedArrays()
+    {
+        /**
+         * When passed an array of a nested array (e.g. [ [ "A" ] ] ), 
+         * $all matches documents where the field contains the nested 
+         * array as an element (e.g. field: [ [ "A" ], ... ]),
+         * or the field equals the nested array (e.g. field: [ "A" ]).
+        */
+        $this->col->insertMany([
+            ['foo' => ['bar', 'baz', ['bad']]],
+            ['foo' => ['bad']],
+            ['foo' => ['foobar', 'baroof']],
+            ['foo' => [1,2,3], 'bar' => [4,5,6]],
+            ['foo' => [99.99,'bar',10], 'bar' => [false,true]],
+            ['foo' => [], 'bar' => []],
+        ]);
+
+        $result = $this->col->count(['foo' => ['$all' => ['bar','baz',['bad']]]]);
+        self::assertThat($result, self::equalTo(1));
+
+        $result = $this->col->count(['foo' => ['$all' => [['bad']] ]]);
+        self::assertThat($result, self::equalTo(2));
+
+        $result = $this->col->count(['foo' => ['$all' => [['foobar', 'baroof']] ]]);
+        self::assertThat($result, self::equalTo(1));
+
+        $result = $this->col->count(['foo' => ['$all' => [['foobar', 'baroof'],'bar'] ]]);
+        self::assertThat($result, self::equalTo(0));
+
+        $result = $this->col->count(['foo' => ['$all' => []],'bar' => ['$all'=>[[]]]]);
+        self::assertThat($result, self::equalTo(1));
+    }
+
+    /**
+     * @depends testInsertOneInsertsDocument
+     */
     public function testInsertOneKeepsBSONObjects()
     {
         $result = $this->col->insertOne(new BSONDocument(['foo' => 'bar']));


### PR DESCRIPTION
The [$all](https://www.mongodb.com/docs/manual/reference/operator/query/all/#mongodb-query-op.-all) operator selects the documents where the value of a field is an array that contains all the specified elements. To specify an $all expression, use the following prototype:

`{ <field>: { $all: [ <value1> , <value2> ... ] } }`

When passed an array of a nested array (e.g. [ [ "A" ] ] ), [$all](https://www.mongodb.com/docs/manual/reference/operator/query/all/#mongodb-query-op.-all) matches documents where the field contains the nested array as an element (e.g. field: [ [ "A" ], ... ]), or the field equals the nested array (e.g. field: [ "A" ]).

Reference: https://www.mongodb.com/docs/manual/reference/operator/query/all/

Closes #30 